### PR TITLE
Disable certificate by default for ksushy emulated bmc

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -134,6 +134,7 @@ platform:
         {% endif %}
         {% else %}
         address: redfish-virtualmedia://CHANGEME:9000/redfish/v1/Systems/kcli/{{ cluster }}-master-{{ num }}
+        disableCertificateVerification: True
         {% endif %}
         username: {{ master['bmc_user']|default(bmc_user) }}
         password: {{ master['bmc_password']|default(bmc_password) }}
@@ -184,6 +185,7 @@ platform:
         {% endif %}
         {% else %}
         address: redfish-virtualmedia://CHANGEME:9000/redfish/v1/Systems/kcli/{{ cluster }}-worker-{{ num }}
+        disableCertificateVerification: True
         {% endif %}
         username: {{ worker['bmc_user']|default(bmc_user) }}
         password: {{ worker['bmc_password']|default(bmc_password) }}


### PR DESCRIPTION
Since ksushy uses https by default certificate verification needs to be disabled to avoid certificate verification errors